### PR TITLE
Dealing with memory and speed issues in permutation analysis for large datasets

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gcapc
 Title: GC Aware Peak Caller
-Version: 1.3.0
+Version: 1.3.1
 Author: Mingxiang Teng and Rafael A. Irizarry
 Maintainer: Mingxiang Teng <tengmx@gmail.com>
 Description: Peak calling for ChIP-seq data with

--- a/R/gcapcPeaks.r
+++ b/R/gcapcPeaks.r
@@ -295,7 +295,7 @@ gcapcPeaks <- function( coverage,gcbias,bdwidth,flank=NULL,prefilter=4L,
     xprev <- 0
 #    system.time(pvsniOld <- sapply(peaksrd$es[1:2000],function(x) sum(pvsn<=x)))
     sprintf("processed %d of %d, vector %d\n", 0, length(esVec), length(pvsn))
-    system.time( 
+#    system.time( 
     for( x in seq_len( length( esVec ) ) ){
 #        if( x %% 500 == 0 ){
 #            cat( sprintf("processed %d of %d, vector length %d\n",
@@ -323,7 +323,7 @@ gcapcPeaks <- function( coverage,gcbias,bdwidth,flank=NULL,prefilter=4L,
         passNumbPrev <- pvsni[x]
         xprev <- x
     }
-    )
+#    )
     pvsni[pvsni==0] <- NA
     peaksrd$pv <- pvs[pvsni]
     peaksrd$pv[peaksrd$es<minpvsn] <- 1

--- a/R/gcapcPeaks.r
+++ b/R/gcapcPeaks.r
@@ -57,13 +57,12 @@
 #' is 3 times or more larger than estimated bind width. The value
 #' needs to be the same as it is when calculating \code{gcbias}.
 #'
-#' @param permsamp Fraction of the values to be used when calculating the percentile
-#' of the permutations (1-pv). For large datasets, the number of values resulting of
+#' @param permsamp Fraction of the values to be used when calculating the (1-pv)*100 percentile
+#' of the permutations. For large datasets, the vector resulting of
 #' the permutation step can be extremely large. Calculating percentiles from very large
-#' vectors can be computationally expensive. However, a very good approximation of
-#' the percentile can be obtained by estimating it from uniformly sampling the permuted
-#' values. This parameter indicates the fraction of permuted values to be used when uniformly
-#' sampling.
+#' vectors can be computationally expensive. However, a very good approximation of the percentiles
+#' can be obtained from a uniform sample of the permuted values. This parameter indicates
+#' the fraction of permuted values to be used to calculate the percentile.
 #'
 #' @return A GRanges of peaks with meta columns:
 #' \item{es}{Estimated enrichment score.}

--- a/man/gcapcPeaks.Rd
+++ b/man/gcapcPeaks.Rd
@@ -6,7 +6,7 @@
 \usage{
 gcapcPeaks(coverage, gcbias, bdwidth, flank = NULL, prefilter = 4L,
   permute = 5L, pv = 0.05, plot = FALSE, genome = "hg19",
-  gctype = c("ladder", "tricube"))
+  gctype = c("ladder", "tricube"), permsamp = NULL)
 }
 \arguments{
 \item{coverage}{A list object returned by function \code{read5endCoverage}.}
@@ -59,6 +59,13 @@ distribution. A more smoother method based on tricube assumption is also
 allowed. However, tricube should be not used if estimated peak half size
 is 3 times or more larger than estimated bind width. The value
 needs to be the same as it is when calculating \code{gcbias}.}
+
+\item{permsamp}{Fraction of the values to be used when calculating the (1-pv)*100 percentile
+of the permutations. For large datasets, the vector resulting of
+the permutation step can be extremely large. Calculating percentiles from very large
+vectors can be computationally expensive. However, a very good approximation of the percentiles
+can be obtained from a uniform sample of the permuted values. This parameter indicates
+the fraction of permuted values to be used to calculate the percentile.}
 }
 \value{
 A GRanges of peaks with meta columns:
@@ -77,4 +84,5 @@ cov <- read5endCoverage(bam)
 bdw <- bindWidth(cov)
 gcb <- gcEffects(cov, bdw, sampling = c(0.15,1))
 gcapcPeaks(cov, gcb, bdw)
+
 }


### PR DESCRIPTION
Hi @tengmx, 

I ran into the problem reported [here](https://support.bioconductor.org/p/102757/) and dig into debugging the error. It is related to the `gcapcPeaks` function. It turns out that, for some datasets, the vector of permuted values can be extremely large (>50 billion) and the functions `quantile` and `density` just break. I solved this by adding an option to sample permuted values from a uniform distribution. I added a parameter `permsamp=` that indicates the fraction of permuted values to use for the size of the sample.  

I also modified some lines of code to speed them up. For the example dataset, these changes improve the runs by only ~5 seconds, but for larger datasets it makes a more substantial difference. 

This version passes `R CMD check` without problems. Let me know if these suggestions make sense!

Alejandro